### PR TITLE
fix: swap order within openChild

### DIFF
--- a/Sources/Coordination/ParentCoordinator.swift
+++ b/Sources/Coordination/ParentCoordinator.swift
@@ -15,8 +15,8 @@ public protocol ParentCoordinator: Coordinator {
 extension ParentCoordinator {
     func openChild(_ childCoordinator: ChildCoordinator) {
         childCoordinators.append(childCoordinator)
-        childCoordinator.start()
         childCoordinator.parentCoordinator = self
+        childCoordinator.start()
     }
 }
 


### PR DESCRIPTION
# fix: swap order within openChild

For apps consuming this package, when using `openChild` and performing checks on the `parentCoordinator` property in the `start()` method of the child coordinator, the parent coordinator is not assigned when the coordinator's start method is called. This PR reverses the order of the calls made in the body of `openChild` to avoid this problem.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
