### PR TITLE
fix: make modal animation configurable

### DIFF
--- a/Sources/Coordination/Flows/AnyCoordinator.swift
+++ b/Sources/Coordination/Flows/AnyCoordinator.swift
@@ -14,8 +14,9 @@ extension AnyCoordinator where Self: ParentCoordinator {
     ///
     /// - Parameters:
     ///   - childCoordinator: The Child Coordinator that should be presented
-    public func openChildModally<T: AnyCoordinator & ChildCoordinator>(_ childCoordinator: T) {
-        root.present(childCoordinator.root, animated: true)
+    public func openChildModally<T: AnyCoordinator & ChildCoordinator>(_ childCoordinator: T,
+                                                                       animated: Bool = true) {
+        root.present(childCoordinator.root, animated: animated)
         openChild(childCoordinator)
     }
 }


### PR DESCRIPTION
# DCMAW-7030: iOS  | Home screen: Implement basic structure for Tab bar Coordinator and add to home screen

The ability to set the animation on opening a child modally is necessary for the flow of the One Login app, this PR implements that ability, defaulting to true.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
