### PR TITLE
ci: update github workflow actions to use commit shas

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build and Test default scheme using any available iPhone simulator
     if: github.event.pull_request.draft == false
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: Add path globally
@@ -27,6 +27,7 @@ jobs:
 
       - name: Run Linter
         run: |
+          brew install swiftlint
           swiftlint --strict
 
       - name: Validate Pull Request Name

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ main ]
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,21 +20,21 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0
-          
+
       - name: Run Linter
         run: |
           swiftlint --strict
-          
+
       - name: Validate Pull Request Name
         id: versioning
-        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # 1.0.0
+        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # pin@v1.0.0
         with:
           ACTION_TYPE: 'Validate'
-            
+
       - name: Build and Test
         run: |
           xcodebuild -scheme Coordination test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
@@ -43,11 +43,11 @@ jobs:
       - name: Run SonarCloud Scanning
         run: |
           bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
-          
+
           brew install sonar-scanner
-          
+
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          
+
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="Coverage.xml" \
@@ -57,11 +57,10 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Check SonarCloud Results
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # pin@v1.1.0
         # Force to fail step after specific time
         timeout-minutes: 5
         env:
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Run Quality Report
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       contents: write
     steps:

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+
 jobs:
   build:
     name: Run Quality Report
@@ -16,10 +17,10 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
-          
+
       - name: Build and Test
         run: |
           xcodebuild -scheme Coordination test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
@@ -28,19 +29,19 @@ jobs:
       - name: Run SonarCloud Scanning
         run: |
           bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
-          
+
           brew install sonar-scanner
-          
+
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="Coverage.xml"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Increment Version
         id: versioning
-        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # 1.0.0
+        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # pin@v1.0.0
         with:
           ACTION_TYPE: Release
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Update GitHub workflow actions to use commit shas

Update GitHub workflow actions to use commit shas for versioning to improve security.
Update `sonarqube-quality-gate-action` to use version 1.1.0
`pin-github-action` also carried out linting for the workflows.
Update GitHub runners to Mac OS 14 and add brew install swiftlint command where required.

[DCMAW-8673](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/440?quickFilter=1326&selectedIssue=DCMAW-8673)

# Checklist

## Before raising your pull request:
- [ ] Commit messages that conform to conventional commit messages

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.



[DCMAW-8673]: https://govukverify.atlassian.net/browse/DCMAW-8673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ