### PR TITLE
feat: v2 tab coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each self-contained flow within the application can conform to the `Coordinator`
  
 `AnyCoordinator` is usable within a hierarchy conforming to UIViewController to open a child modally.
 
-`TabCoordinator` is usable within a tab bar hierarchy to open a child modally.
+`TabCoordinator` is usable within a tab bar hierarchy to open a child modally. (deprecated)
 
 `TabCoordinatorV2` is usable within a tab bar hierarchy to open a child modally, with the addition of a delegate to alert when the child tab has been selected.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Each self-contained flow within the application can conform to the `Coordinator`
 
 `TabCoordinator` is usable within a tab bar hierarchy to open a child modally.
 
+`TabCoordinatorV2` is usable within a tab bar hierarchy to open a child modally, with the addition of a delegate to alert when the child tab has been selected.
+
 `NavigationCoordinator` is usable within a navigation hierarchy to open a child inline, it should also act as the navigation controller delegate.
 
 ### `ParentCoordinator` types can present `ChildCoordinator` types, when sub-flows are needed.
@@ -102,6 +104,32 @@ class PrimaryCoordinator: TabCoorinator, ParentCoordinator {
 class SecondaryCoordinator: AnyCoordinator, ChildCoordinator {
     let root: UIViewController
     weak var parentCoordinator: ParentCoordinator?
+}
+```
+
+Using the Coordinator pattern in a tab bar navigation, conforming to `TabCoordinatorV2` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened as a tab. Conforming to `ChildCoordinator` allows finishing the child which calls the `didRegainFocus(fromChild child: ChildCoordinator?). Conforming to `TabItemCoordinator` allows callbacks for `tabBarController` delegate)`
+
+```swift
+class PrimaryCoordinator: TabCoorinatorV2, ParentCoordinator {
+    let root: UITabBarController
+    var childCoordinators: [ChildCoordinator] = []
+    
+    lazy var delegate: TabCoordinatorDelegate? = {
+        TabCoordinatorDelegate(coordinator: self)
+    }()
+    
+    override func didRegainFocus(fromChild child: ChildCoordinator?) {
+        // Perform any operations after the parent regains focus
+    }
+}
+
+class SecondaryCoordinator: AnyCoordinator, ChildCoordinator, TabItemCoordinator  {
+    let root: UIViewController
+    weak var parentCoordinator: ParentCoordinator?
+    
+    func didBecomeSelected() {
+        // Tab has been selected
+    }
 }
 ```
 

--- a/Sources/Coordination/Flows/TabCoordinator.swift
+++ b/Sources/Coordination/Flows/TabCoordinator.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// A coordinator which displays one or more view controllers within a UITabBarController context.
 @MainActor
-public protocol TabCoordinator: Coordinator {
+public protocol TabCoordinator: Coordinator, UITabBarControllerDelegate {
     var root: UITabBarController { get }
 }
 
@@ -17,5 +17,24 @@ public extension TabCoordinator where Self: ParentCoordinator {
     func addTab<T: AnyCoordinator & ChildCoordinator>(_ childCoordinator: T) {
         root.addChild(childCoordinator.root)
         openChild(childCoordinator)
+    }
+}
+
+public protocol TabItemCoordinator: Coordinator {
+    func didBecomeSelected()
+}
+
+public extension TabItemCoordinator where Self: ParentCoordinator {
+    @MainActor
+    func tabBarController(_ tabBarController: UITabBarController,
+                          didSelect viewController: UIViewController) {
+        
+        if let children = childCoordinators as? [any AnyCoordinator] {
+            let this = children.first(where: {$0.root == viewController})
+            
+            if this != nil {
+                didBecomeSelected()
+            }
+        }
     }
 }

--- a/Sources/Coordination/Flows/TabCoordinator.swift
+++ b/Sources/Coordination/Flows/TabCoordinator.swift
@@ -6,6 +6,7 @@ import UIKit
 @MainActor
 public protocol TabCoordinator: Coordinator, UITabBarControllerDelegate {
     var root: UITabBarController { get }
+    func didBecomeSelected()
 }
 
 public extension TabCoordinator where Self: ParentCoordinator {
@@ -18,13 +19,14 @@ public extension TabCoordinator where Self: ParentCoordinator {
         root.addChild(childCoordinator.root)
         openChild(childCoordinator)
     }
+    
 }
 
-public protocol TabItemCoordinator: Coordinator {
-    func didBecomeSelected()
-}
+//public protocol TabItemCoordinator: Coordinator {
+//    func didBecomeSelected()
+//}
 
-public extension TabItemCoordinator where Self: ParentCoordinator {
+public extension TabCoordinator where Self: ParentCoordinator {
     @MainActor
     func tabBarController(_ tabBarController: UITabBarController,
                           didSelect viewController: UIViewController) {

--- a/Sources/Coordination/Flows/TabCoordinator.swift
+++ b/Sources/Coordination/Flows/TabCoordinator.swift
@@ -4,9 +4,47 @@ import UIKit
 ///
 /// A coordinator which displays one or more view controllers within a UITabBarController context.
 @MainActor
-public protocol TabCoordinator: Coordinator, UITabBarControllerDelegate {
+public protocol TabCoordinator: Coordinator {
     var root: UITabBarController { get }
 }
+
+class TabSomething: NSObject, TabCoordinator {
+    private (set) var root: UITabBarController
+    var childCoordinators: [any ChildCoordinator] = []
+    
+    init(root: UITabBarController) {
+        self.root = root
+    }
+    
+    public func start() {
+        // Empty Implementation
+    }
+}
+
+extension TabSomething: UITabBarControllerDelegate, ParentCoordinator {
+    func tabBarController(_ tabBarController: UITabBarController,
+                          didSelect viewController: UIViewController) {
+
+        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
+            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
+        selectedChild.didBecomeSelected()
+    }
+}
+
+//public extension TabCoordinator where Self: ParentCoordinator {
+//    func tabBarController(_ tabBarController: UITabBarController,
+//                          didSelect viewController: UIViewController) {
+//
+//        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
+//            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
+//        selectedChild.didBecomeSelected()
+//    }
+//}
+
+public protocol TabItemCoordinator: Coordinator {
+    func didBecomeSelected()
+}
+
 
 public extension TabCoordinator where Self: ParentCoordinator {
     /// Opens a child coordinator flow within the root tab bar controller
@@ -39,18 +77,3 @@ public extension TabCoordinator where Self: ParentCoordinator {
 //        }
 //    }
 //}
-
-public extension TabCoordinator where Self: ParentCoordinator {
-    @MainActor
-    func tabBarController(_ tabBarController: UITabBarController,
-                          didSelect viewController: UIViewController) {
-
-        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
-            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
-        selectedChild.didBecomeSelected()
-    }
-}
-
-public protocol TabItemCoordinator: Coordinator {
-    func didBecomeSelected()
-}

--- a/Sources/Coordination/Flows/TabCoordinator.swift
+++ b/Sources/Coordination/Flows/TabCoordinator.swift
@@ -3,6 +3,7 @@ import UIKit
 /// Tab Coordinator
 ///
 /// A coordinator which displays one or more view controllers within a UITabBarController context.
+@available(*, deprecated, renamed: "TabCoordinatorV2", message: "This protocol is deprecated and will be removed in a future release")
 @MainActor
 public protocol TabCoordinator: Coordinator {
     var root: UITabBarController { get }
@@ -18,37 +19,4 @@ public extension TabCoordinator where Self: ParentCoordinator {
         root.addChild(childCoordinator.root)
         openChild(childCoordinator)
     }
-}
-
-
-open class TabNavigationCoordinator : NSObject, TabCoordinator {
-    private (set) public var root: UITabBarController
-    public var childCoordinators: [any ChildCoordinator] = []
-    
-    public init(root: UITabBarController) {
-        self.root = root
-    }
-    
-    open func start() {
-        // Empty Implementation
-    }
-    
-    open func didRegainFocus(fromChild child: (any ChildCoordinator)?) {
-        // Empty Implementation
-    }
-}
-
-extension TabNavigationCoordinator : UITabBarControllerDelegate, ParentCoordinator {
-    public func tabBarController(_ tabBarController: UITabBarController,
-                          didSelect viewController: UIViewController) {
-
-        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
-            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
-        selectedChild.didBecomeSelected()
-    }
-}
-
-@MainActor
-public protocol TabItemCoordinator: Coordinator {
-    func didBecomeSelected()
 }

--- a/Sources/Coordination/Flows/TabCoordinator.swift
+++ b/Sources/Coordination/Flows/TabCoordinator.swift
@@ -8,44 +8,6 @@ public protocol TabCoordinator: Coordinator {
     var root: UITabBarController { get }
 }
 
-class TabSomething: NSObject, TabCoordinator {
-    private (set) var root: UITabBarController
-    var childCoordinators: [any ChildCoordinator] = []
-    
-    init(root: UITabBarController) {
-        self.root = root
-    }
-    
-    public func start() {
-        // Empty Implementation
-    }
-}
-
-extension TabSomething: UITabBarControllerDelegate, ParentCoordinator {
-    func tabBarController(_ tabBarController: UITabBarController,
-                          didSelect viewController: UIViewController) {
-
-        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
-            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
-        selectedChild.didBecomeSelected()
-    }
-}
-
-//public extension TabCoordinator where Self: ParentCoordinator {
-//    func tabBarController(_ tabBarController: UITabBarController,
-//                          didSelect viewController: UIViewController) {
-//
-//        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
-//            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
-//        selectedChild.didBecomeSelected()
-//    }
-//}
-
-public protocol TabItemCoordinator: Coordinator {
-    func didBecomeSelected()
-}
-
-
 public extension TabCoordinator where Self: ParentCoordinator {
     /// Opens a child coordinator flow within the root tab bar controller
     /// Child coordinators must also conform to the AnyCoordinator protocol and have the same navigation controller instance as their root.
@@ -56,24 +18,37 @@ public extension TabCoordinator where Self: ParentCoordinator {
         root.addChild(childCoordinator.root)
         openChild(childCoordinator)
     }
-    
 }
 
-//public protocol TabItemCoordinator: Coordinator {
-//    func didBecomeSelected()
-//}
-//
-//public extension TabCoordinator where Self: ParentCoordinator {
-//    @MainActor
-//    func tabBarController(_ tabBarController: UITabBarController,
-//                          didSelect viewController: UIViewController) {
-//        
-//        if let children = childCoordinators as? [any AnyCoordinator] {
-//            let this = children.first(where: {$0.root == viewController})
-//            
-//            if this != nil {
-//                didBecomeSelected()
-//            }
-//        }
-//    }
-//}
+
+open class TabNavigationCoordinator : NSObject, TabCoordinator {
+    private (set) public var root: UITabBarController
+    public var childCoordinators: [any ChildCoordinator] = []
+    
+    public init(root: UITabBarController) {
+        self.root = root
+    }
+    
+    open func start() {
+        // Empty Implementation
+    }
+    
+    open func didRegainFocus(fromChild child: (any ChildCoordinator)?) {
+        // Empty Implementation
+    }
+}
+
+extension TabNavigationCoordinator : UITabBarControllerDelegate, ParentCoordinator {
+    public func tabBarController(_ tabBarController: UITabBarController,
+                          didSelect viewController: UIViewController) {
+
+        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
+            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
+        selectedChild.didBecomeSelected()
+    }
+}
+
+@MainActor
+public protocol TabItemCoordinator: Coordinator {
+    func didBecomeSelected()
+}

--- a/Sources/Coordination/Flows/TabCoordinator.swift
+++ b/Sources/Coordination/Flows/TabCoordinator.swift
@@ -6,7 +6,6 @@ import UIKit
 @MainActor
 public protocol TabCoordinator: Coordinator, UITabBarControllerDelegate {
     var root: UITabBarController { get }
-    func didBecomeSelected()
 }
 
 public extension TabCoordinator where Self: ParentCoordinator {
@@ -25,18 +24,33 @@ public extension TabCoordinator where Self: ParentCoordinator {
 //public protocol TabItemCoordinator: Coordinator {
 //    func didBecomeSelected()
 //}
+//
+//public extension TabCoordinator where Self: ParentCoordinator {
+//    @MainActor
+//    func tabBarController(_ tabBarController: UITabBarController,
+//                          didSelect viewController: UIViewController) {
+//        
+//        if let children = childCoordinators as? [any AnyCoordinator] {
+//            let this = children.first(where: {$0.root == viewController})
+//            
+//            if this != nil {
+//                didBecomeSelected()
+//            }
+//        }
+//    }
+//}
 
 public extension TabCoordinator where Self: ParentCoordinator {
     @MainActor
     func tabBarController(_ tabBarController: UITabBarController,
                           didSelect viewController: UIViewController) {
-        
-        if let children = childCoordinators as? [any AnyCoordinator] {
-            let this = children.first(where: {$0.root == viewController})
-            
-            if this != nil {
-                didBecomeSelected()
-            }
-        }
+
+        guard let selectedChild = (childCoordinators as? [any AnyCoordinator])?
+            .first(where: { $0.root == viewController }) as? TabItemCoordinator else { return }
+        selectedChild.didBecomeSelected()
     }
+}
+
+public protocol TabItemCoordinator: Coordinator {
+    func didBecomeSelected()
 }

--- a/Sources/Coordination/Flows/TabCoordinatorV2.swift
+++ b/Sources/Coordination/Flows/TabCoordinatorV2.swift
@@ -25,13 +25,13 @@ public extension TabCoordinatorV2 where Self: ParentCoordinator {
 public class TabCoordinatorDelegate: NSObject,
                                      UITabBarControllerDelegate {
     weak var coordinator: (any ParentCoordinator)?
-
+    
     public init(coordinator: any ParentCoordinator) {
         self.coordinator = coordinator
     }
-
+    
     public func tabBarController(_ tabBarController: UITabBarController,
-                          didSelect viewController: UIViewController) {
+                                 didSelect viewController: UIViewController) {
         guard let children = coordinator?.childCoordinators as? [any AnyCoordinator],
               let selectedChild = children.first(where: { $0.root == viewController })
                 as? TabItemCoordinator else {

--- a/Sources/Coordination/Flows/TabCoordinatorV2.swift
+++ b/Sources/Coordination/Flows/TabCoordinatorV2.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+/// Tab Coordinator
+///
+/// A coordinator which displays one or more view controllers within a UITabBarController context.
+@MainActor
+public protocol TabCoordinatorV2: Coordinator {
+    var root: UITabBarController { get }
+    var delegate: TabCoordinatorDelegate? { get }
+}
+
+public extension TabCoordinatorV2 where Self: ParentCoordinator {
+    /// Opens a child coordinator flow within the root tab bar controller
+    /// Child coordinators must also conform to the AnyCoordinator protocol and have the same navigation controller instance as their root.
+    ///
+    /// - Parameters:
+    ///   - childCoordinator: The Child Coordinator that should be presented
+    func addTab<T: AnyCoordinator & ChildCoordinator>(_ childCoordinator: T) {
+        root.addChild(childCoordinator.root)
+        root.delegate = delegate
+        openChild(childCoordinator)
+    }
+}
+
+public class TabCoordinatorDelegate: NSObject,
+                                     UITabBarControllerDelegate {
+    weak var coordinator: (any ParentCoordinator)?
+
+    public init(coordinator: any ParentCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    public func tabBarController(_ tabBarController: UITabBarController,
+                          didSelect viewController: UIViewController) {
+        guard let children = coordinator?.childCoordinators as? [any AnyCoordinator],
+              let selectedChild = children.first(where: { $0.root == viewController })
+                as? TabItemCoordinator else {
+            return
+        }
+        selectedChild.didBecomeSelected()
+    }
+}
+
+@MainActor
+public protocol TabItemCoordinator: Coordinator {
+    func didBecomeSelected()
+}

--- a/Tests/CoordinationTests/Mocks/MockChildTabV2Coordinator.swift
+++ b/Tests/CoordinationTests/Mocks/MockChildTabV2Coordinator.swift
@@ -1,0 +1,36 @@
+import Coordination
+import UIKit
+
+final class MockChildTabV2Coordinator: NSObject,
+                                       AnyCoordinator,
+                                       ChildCoordinator,
+                                       NavigationCoordinator,
+                                       TabItemCoordinator {
+    var parentCoordinator: ParentCoordinator?
+    
+    var coordinatorDidStart = false
+    var did_becomeSelected = false
+    
+    let root: UINavigationController
+    
+    var isTabChild: Bool
+    
+    init(isTabChild: Bool = true,
+         root: UINavigationController = UINavigationController(),
+         parentCoordinator: ParentCoordinator) {
+        self.isTabChild = isTabChild
+        self.root = root
+        self.parentCoordinator = parentCoordinator
+    }
+    
+    func didBecomeSelected() {
+        self.did_becomeSelected = true
+    }
+    
+    func start() {
+        self.coordinatorDidStart = true
+        if isTabChild {
+            root.tabBarItem = UITabBarItem(title: "Home", image: UIImage(systemName: "house"), tag: 0)
+        }
+    }
+}

--- a/Tests/CoordinationTests/Mocks/MockTabCoordinatorV2.swift
+++ b/Tests/CoordinationTests/Mocks/MockTabCoordinatorV2.swift
@@ -1,6 +1,6 @@
 import Coordination
-import UIKit
 import Foundation
+import UIKit
 
 final class MockTabCoordinatorV2: NSObject,
                                   AnyCoordinator,

--- a/Tests/CoordinationTests/Mocks/MockTabCoordinatorV2.swift
+++ b/Tests/CoordinationTests/Mocks/MockTabCoordinatorV2.swift
@@ -1,0 +1,29 @@
+import Coordination
+import UIKit
+import Foundation
+
+final class MockTabCoordinatorV2: NSObject,
+                                  AnyCoordinator,
+                                  TabCoordinatorV2,
+                                  ParentCoordinator {
+    lazy var delegate: TabCoordinatorDelegate? = {
+        TabCoordinatorDelegate(coordinator: self)
+    }()
+    
+    var root: UITabBarController = UITabBarController()
+    var childCoordinators: [ChildCoordinator] = []
+    
+    var coordinatorDidStart = false
+    
+    func start() {
+        self.coordinatorDidStart = true
+    }
+    
+    func addTabs() {
+        let child = MockChildTabV2Coordinator(parentCoordinator: self)
+        addTab(child)
+        
+        let secondChild = MockChildTabV2Coordinator(parentCoordinator: self)
+        addTab(secondChild)
+    }
+}

--- a/Tests/CoordinationTests/V2TabCoordinatorTests.swift
+++ b/Tests/CoordinationTests/V2TabCoordinatorTests.swift
@@ -1,0 +1,43 @@
+@testable import Coordination
+import XCTest
+
+
+final class V2TabCoordinatorTests: XCTestCase {
+    var sut: MockTabCoordinatorV2!
+    
+    @MainActor
+    override func setUp() {
+        sut = MockTabCoordinatorV2()
+    }
+    
+    override func tearDown() {
+        sut = nil
+    }
+}
+
+extension V2TabCoordinatorTests {
+    @MainActor
+    func testCoordinatorStart() {
+        sut.start()
+        XCTAssertTrue(sut.coordinatorDidStart)
+    }
+    
+    @MainActor
+    func testAddingTab() throws {
+        XCTAssertEqual(sut.childCoordinators.count, 0)
+        XCTAssertNil(sut.root.tabBar.items)
+        
+        sut.start()
+        sut.addTabs()
+        
+        guard let vc = sut.root.viewControllers?[0] else {
+            XCTFail("no vc's set")
+            return
+        }
+        
+        sut.root.delegate?.tabBarController?(sut.root, didSelect: vc)
+        
+        let child = try XCTUnwrap(sut.childCoordinators.first as? MockChildTabV2Coordinator)
+        XCTAssertTrue(child.did_becomeSelected)
+    }
+}


### PR DESCRIPTION
# feat: v2 tab coordinator

_Thank you for your contribution to the project._

Deprecating TabCoordinator, and adding a new TabCoordinator so that we can use the delegate to get told when a tab has been tapped.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
