### PR TITLE
feat: exposing openChild as a public API and correcting matching operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each self-contained flow within the application can conform to the `Coordinator`
 
 #### Implementing concrete Types conforming to the above protocols:
 
-Using the Coordinator pattern through a navigation stack, conforming to `NavigationCoordinator` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened inline and assigns the `UINavigationControllerDelegate`. Conforming to `ChildCoordinator` allows finishing the child which calls the `didRegainFocus(fromChild child: ChildCoordinator?)`
+Using the Coordinator pattern through a navigation stack, conforming to `NavigationCoordinator` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened inline and assigns the `UINavigationControllerDelegate`. Conforming to `ChildCoordinator` allows finishing the child which calls `didRegainFocus(fromChild child: ChildCoordinator?)`
 
 ```swift
 class PrimaryCoordinator: NavigationCoordinator, ParentCoordinator {
@@ -71,7 +71,7 @@ class SecondaryCoordinator: NavigationCoordinator, ChildCoordinator {
 }
 ```
 
-Using the Coordinator pattern through a navigation stack but needing a child coordinator whose child view controllers can be presented modally on a parent coordinator, conforming to `AnyCoordinator` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened modally. Conforming to `ChildCoordinator` allows finishing the child which calls the `didRegainFocus(fromChild child: ChildCoordinator?)`
+Using the Coordinator pattern through a navigation stack but needing a child coordinator whose child view controllers can be presented modally on a parent coordinator, conforming to `AnyCoordinator` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened modally. Conforming to `ChildCoordinator` allows finishing the child which calls `didRegainFocus(fromChild child: ChildCoordinator?)`
 
 ```swift
 class PrimaryCoordinator: AnyCoordinator, ParentCoordinator {
@@ -89,7 +89,7 @@ class SecondaryCoordinator: AnyCoordinator, ChildCoordinator {
 }
 ```
 
-Using the Coordinator pattern in a tab bar navigation, conforming to `TabCoordinator` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened as a tab. Conforming to `ChildCoordinator` allows finishing the child which calls the `didRegainFocus(fromChild child: ChildCoordinator?)`
+Using the Coordinator pattern in a tab bar navigation, conforming to `TabCoordinator` is appropriate. Also conforming to `ParentCoordinator` allows a child to be opened as a tab. Conforming to `ChildCoordinator` allows finishing the child which calls `didRegainFocus(fromChild child: ChildCoordinator?)`
 
 ```swift
 class PrimaryCoordinator: TabCoorinator, ParentCoordinator {
@@ -135,7 +135,7 @@ class SecondaryCoordinator: AnyCoordinator, ChildCoordinator, TabItemCoordinator
 
 #### Example of using the Coordinator pattern with the above Types:
 
-When creating the parent conforming to `NavigationCoordinator`, calling the `openChildInline()` method to create and start the child
+When creating the parent conforming to `NavigationCoordinator`, calling the `openChildInline()` method to add and start the child
 
 ```swift
 let parentCoordinator = PrimaryCoordinator(root: UINavigationController())
@@ -143,7 +143,7 @@ let childCoordinator = SecondaryCoordinator(root: root)
 firstCoordinator.openChildInline(childCoordinator)
 ```
 
-When creating the parent conforming to `AnyCoordinator`, calling the `openChildModally()` method to create and start the child
+When creating the parent conforming to `AnyCoordinator`, calling the `openChildModally()` method to add and start the child
 
 ```swift
 let parentCoordinator = PrimaryCoordinator(root: UINavigationController())
@@ -151,12 +151,21 @@ let childCoordinator = SecondaryCoordinator(root: UIViewController())
 firstCoordinator.openChildModally(childCoordinator)
 ```
 
-When creating the parent conforming to `TabCoordinator`, calling the `addTab()` method to create and start the child
+When creating the parent conforming to `TabCoordinator`, calling the `addTab()` method to add and start the child
 
 ```swift
-let parentCoordinator = PrimaryCoordinator(root: UINavigationController())
-let childCoordinator = SecondaryCoordinator(root: UIViewController())
+let parentCoordinator = PrimaryCoordinator(root: UITabBarController())
+let childCoordinator = SecondaryCoordinator(root: UINavigationController())
 firstCoordinator.addTab(childCoordinator)
+```
+
+When implementing a custom coordinator presentation, calling `openChild()` method to add and start the child.
+> **Note:** Consider using the above methods for presenting a coordinator as these will be appropriate for most use cases.
+
+```swift
+let parentCoordinator = PrimaryCoordinator()
+let childCoordinator = SecondaryCoordinator()
+firstCoordinator.openChild(childCoordinator)
 ```
 
 Once the child has finished, using the `finish()` method to restore focus to the parent

--- a/Sources/Coordination/Flows/TabCoordinatorV2.swift
+++ b/Sources/Coordination/Flows/TabCoordinatorV2.swift
@@ -33,7 +33,7 @@ public class TabCoordinatorDelegate: NSObject,
     public func tabBarController(_ tabBarController: UITabBarController,
                                  didSelect viewController: UIViewController) {
         guard let children = coordinator?.childCoordinators as? [any AnyCoordinator],
-              let selectedChild = children.first(where: { $0.root == viewController })
+              let selectedChild = children.first(where: { $0.root === viewController })
                 as? TabItemCoordinator else {
             return
         }

--- a/Sources/Coordination/ParentCoordinator.swift
+++ b/Sources/Coordination/ParentCoordinator.swift
@@ -13,6 +13,14 @@ public protocol ParentCoordinator: Coordinator {
 }
 
 extension ParentCoordinator {
+    /// openChild
+    /// Start tracking a new child coordinator.
+    /// - Parameter child: The child coordinator to be tracked
+    ///
+    /// This method should only be called directly if implementing a custom coordinator presentation.
+    /// In other cases you should call the relevant openChild method for the relevant presentation style.
+    /// For example: `openChildModally` should be used for modal presentation.
+    ///
     public func openChild(_ childCoordinator: ChildCoordinator) {
         childCoordinators.append(childCoordinator)
         childCoordinator.parentCoordinator = self

--- a/Sources/Coordination/ParentCoordinator.swift
+++ b/Sources/Coordination/ParentCoordinator.swift
@@ -13,7 +13,7 @@ public protocol ParentCoordinator: Coordinator {
 }
 
 extension ParentCoordinator {
-    func openChild(_ childCoordinator: ChildCoordinator) {
+    public func openChild(_ childCoordinator: ChildCoordinator) {
         childCoordinators.append(childCoordinator)
         childCoordinator.parentCoordinator = self
         childCoordinator.start()

--- a/Tests/CoordinationTests/Mocks/MockChildCoordinator.swift
+++ b/Tests/CoordinationTests/Mocks/MockChildCoordinator.swift
@@ -5,8 +5,9 @@ final class MockChildCoordinator: NSObject,
                                   AnyCoordinator,
                                   ChildCoordinator,
                                   NavigationCoordinator {
-    var parentCoordinator: ParentCoordinator?
     let root: UINavigationController
+    weak var parentCoordinator: ParentCoordinator?
+    
     var isTabChild: Bool
     
     var coordinatorDidStart = false

--- a/Tests/CoordinationTests/Mocks/MockChildTabV2Coordinator.swift
+++ b/Tests/CoordinationTests/Mocks/MockChildTabV2Coordinator.swift
@@ -6,20 +6,17 @@ final class MockChildTabV2Coordinator: NSObject,
                                        ChildCoordinator,
                                        NavigationCoordinator,
                                        TabItemCoordinator {
-    var parentCoordinator: ParentCoordinator?
-    
-    var coordinatorDidStart = false
-    var did_becomeSelected = false
-    
-    let root: UINavigationController
+    let root = UINavigationController()
+    weak var parentCoordinator: ParentCoordinator?
     
     var isTabChild: Bool
     
+    var coordinatorDidStart = false
+    var did_becomeSelected = false
+        
     init(isTabChild: Bool = true,
-         root: UINavigationController = UINavigationController(),
          parentCoordinator: ParentCoordinator) {
         self.isTabChild = isTabChild
-        self.root = root
         self.parentCoordinator = parentCoordinator
     }
     

--- a/Tests/CoordinationTests/Mocks/MockNavigationCoordinator.swift
+++ b/Tests/CoordinationTests/Mocks/MockNavigationCoordinator.swift
@@ -5,10 +5,8 @@ final class MockNavigationCoordinator: NSObject,
                                        AnyCoordinator,
                                        NavigationCoordinator,
                                        ParentCoordinator {
-    
-    var root: UINavigationController = UINavigationController()
-    
-    var childCoordinators: [ChildCoordinator] = []
+    let root = UINavigationController()
+    var childCoordinators = [ChildCoordinator]()
     
     var coordinatorDidStart = false
     

--- a/Tests/CoordinationTests/Mocks/MockParentCoordinator.swift
+++ b/Tests/CoordinationTests/Mocks/MockParentCoordinator.swift
@@ -4,9 +4,8 @@ import UIKit
 final class MockParentCoordinator: NSObject,
                                    AnyCoordinator,
                                    ParentCoordinator {
-    
-    let root: UIViewController = UIViewController()
-    var childCoordinators: [ChildCoordinator] = []
+    let root = UIViewController()
+    var childCoordinators = [ChildCoordinator]()
     
     var coordinatorDidStart = false
     

--- a/Tests/CoordinationTests/Mocks/MockTabCoordinator.swift
+++ b/Tests/CoordinationTests/Mocks/MockTabCoordinator.swift
@@ -5,9 +5,8 @@ final class MockTabCoordinator: NSObject,
                                 AnyCoordinator,
                                 TabCoordinator,
                                 ParentCoordinator {
-    
-    var root: UITabBarController = UITabBarController()
-    var childCoordinators: [ChildCoordinator] = []
+    let root = UITabBarController()
+    var childCoordinators = [ChildCoordinator]()
     
     var coordinatorDidStart = false
     

--- a/Tests/CoordinationTests/Mocks/MockTabCoordinatorV2.swift
+++ b/Tests/CoordinationTests/Mocks/MockTabCoordinatorV2.swift
@@ -10,8 +10,8 @@ final class MockTabCoordinatorV2: NSObject,
         TabCoordinatorDelegate(coordinator: self)
     }()
     
-    var root: UITabBarController = UITabBarController()
-    var childCoordinators: [ChildCoordinator] = []
+    let root = UITabBarController()
+    var childCoordinators = [ChildCoordinator]()
     
     var coordinatorDidStart = false
     

--- a/Tests/CoordinationTests/ParentCoordinatorTests.swift
+++ b/Tests/CoordinationTests/ParentCoordinatorTests.swift
@@ -1,4 +1,3 @@
-@testable import Coordination
 import XCTest
 
 final class ParentCoordinatorTests: XCTestCase {

--- a/Tests/CoordinationTests/TabCoordinatorTests.swift
+++ b/Tests/CoordinationTests/TabCoordinatorTests.swift
@@ -1,6 +1,4 @@
-@testable import Coordination
 import XCTest
-
 
 final class TabCoordinatorTests: XCTestCase {
     var sut: MockTabCoordinator!

--- a/Tests/CoordinationTests/V2TabCoordinatorTests.swift
+++ b/Tests/CoordinationTests/V2TabCoordinatorTests.swift
@@ -1,6 +1,4 @@
-@testable import Coordination
 import XCTest
-
 
 final class V2TabCoordinatorTests: XCTestCase {
     var sut: MockTabCoordinatorV2!


### PR DESCRIPTION
# DCMAW-10265: Expose openChild API

Exposing openChild as a public API from the Coordination package for the use of custom coordination flows which don't fit in the process of other, more specific coordination flows.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
