### PR TITLE
fix: DCMAW-21998: Fix checkov error

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,13 +59,13 @@ jobs:
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
-            -Dsonar.pullrequest.branch="$PULL_HEAD_REF" \
-            -Dsonar.pullrequest.base="$PULL_BASE_REF"
+            -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" \
+            -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_HEAD_REF: ${{ github.head_ref }}
-          PULL_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@7a5fffe8e523c40e0c740b6bc2712ab503e52efa # pin@v1.2.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,6 +51,8 @@ jobs:
         run: |
           bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
+          brew install sonar-scanner
+
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
           sonar-scanner \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,19 +51,19 @@ jobs:
         run: |
           bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
-          brew install sonar-scanner
-
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
-            -Dsonar.pullrequest.branch=${{github.head_ref}} \
-            -Dsonar.pullrequest.base=${{github.base_ref}}
+            -Dsonar.pullrequest.branch="$PULL_HEAD_REF" \
+            -Dsonar.pullrequest.base="$PULL_BASE_REF"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_HEAD_REF: ${{ github.head_ref }}
+          PULL_BASE_REF: ${{ github.base_ref }}
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@7a5fffe8e523c40e0c740b6bc2712ab503e52efa # pin@v1.2.1


### PR DESCRIPTION
# Description

The failure CKV_GHA_2 occurs because GitHub Actions context expressions (like ${{ github.head_ref }}) are directly expanded into inline bash scripts before execution.

If a user creates a pull request from a maliciously named branch (e.g., main; rm -rf /), that string will be interpolated directly into the script line, causing arbitrary command execution.

By mapping ${{ github.head_ref }} to an environment variable (PULL_HEAD_REF), the shell treats the value strictly as a data string inside standard double quotes ("$PULL_HEAD_REF"), eliminating shell code execution risks.

Passing:
<img width="445" height="227" alt="Screenshot 2026-08-11 at 13 49 54" src="https://github.com/user-attachments/assets/aff17ff3-0dd2-4df1-bbd8-0e511f463a17" />

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
